### PR TITLE
fix: pass passphrase to the mnemonic.seedHex in accountDIDPrivateKey

### DIFF
--- a/Sources/LibAuk/Utils/Keys.swift
+++ b/Sources/LibAuk/Utils/Keys.swift
@@ -51,7 +51,7 @@ class Keys {
     }
     
     static func accountDIDPrivateKey(mnemonic: BIP39Mnemonic, passphrase: String = "") throws -> Secp256k1.Signing.PrivateKey {
-        let masterKey = try HDKey(seed: mnemonic.seedHex(passphrase: ""))
+        let masterKey = try HDKey(seed: mnemonic.seedHex(passphrase: passphrase))
         let derivationPath = try BIP32Path(string: Constant.accountDerivationPath)
         let account = try masterKey.derive(using: derivationPath)
         


### PR DESCRIPTION
https://github.com/autonomy-system/autonomy-mobile-security-audit/issues/9