### PR TITLE
fix: change license from MIT to BSD-2-Clause

### DIFF
--- a/LibAuk.podspec
+++ b/LibAuk.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = '0.1.1'
   s.summary          = 'Autonomy KMS written in Swift.'
   s.homepage         = 'https://bitmark.com'
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.license          = { :type => 'BSD-2-Clause', :file => 'LICENSE' }
   s.author           = { 'Bitmark Inc' => 'support@bitmark.com' }
   s.source           = { :git => 'https://github.com/bitmark-inc/libauk-swift.git', :tag => s.version.to_s }
   s.ios.deployment_target = '14.0'


### PR DESCRIPTION
[libauk-swift: License in podspec is different from actual license file](https://github.com/autonomy-system/autonomy-mobile-security-audit/issues/3)