### PR TITLE
fix(security_audit): 7 check input length

### DIFF
--- a/Sources/LibAuk/Utils/secp256k1/Secp256k1.swift
+++ b/Sources/LibAuk/Utils/secp256k1/Secp256k1.swift
@@ -266,7 +266,8 @@ extension Secp256k1.Signing {
             var cSig = secp256k1_ecdsa_signature()
 
             // parse and serialize der
-            guard secp256k1_ecdsa_signature_parse_compact(context, &cSig, rawSignatureBytes) == 1,
+            guard rawSignatureBytes.count == 64,
+                secp256k1_ecdsa_signature_parse_compact(context, &cSig, rawSignatureBytes) == 1,
                   secp256k1_ecdsa_signature_serialize_der(context, &derSignature, &derSize, &cSig) == 1 else {
                 throw Secp256k1Error.invalidSignature
             }


### PR DESCRIPTION
[libauk-swift: Secp256k1 wrapper does not verify input lengths](https://github.com/autonomy-system/autonomy-mobile-security-audit/issues/7)